### PR TITLE
MSPA-3785: Changes to make the project archivable

### DIFF
--- a/process-helper.gemspec
+++ b/process-helper.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'process-helper'
-  s.version     = '1.2.0'
+  s.version     = '1.2.1'
   s.date        = '2015-06-29'
   s.summary     = 'Utility for managing sub processes.'
   s.description = 'Utility for managing sub processes.'

--- a/spec/process_helper_spec.rb
+++ b/spec/process_helper_spec.rb
@@ -10,7 +10,7 @@ end
 module ProcessHelper
 
   describe ProcessHelper do
-    context 'Things...' do
+    context 'Tests' do
       it 'It should start a process and capture the exit status (success)' do
         process = ProcessHelper.new
         process.start('true')


### PR DESCRIPTION
Replaces "Things..." text in the process_helper_spec file with the more accurate descriptor "Tests"
Bumps the version number from 1.2.0 to 1.2.1

Creating a new version of process-helper will enable testing of MSPA-3785